### PR TITLE
Change into the correct dir. before `make recover`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Flashing instructions
  git clone -b smart_dsu https://github.com/wocsor/panda.git smart_dsu
  cd smart_dsu/board/tools && killall boardd
  ./enter_download_mode.py
- make recover
+ cd .. && make recover
  reboot
  ```
 ### From Windows:


### PR DESCRIPTION
...
root@localhost:/data$ cd smart_dsu/board/tools && killall boardd
root@localhost:/data/smart_dsu/board/tools$ ./enter_download_mode.py
found device
Device download mode enabled.
root@localhost:/data/smart_dsu/board/tools$ make recover
make: *** No rule to make target 'recover'.  Stop.
root@localhost:/data/smart_dsu/board/tools$ ls -ltr
total 428
-rwx------ 1 root root 116048 Feb 15 01:25 dfu-util-aarch64
-rwx------ 1 root root 159256 Feb 15 01:25 dfu-util-aarch64-linux
-rwx------ 1 root root    846 Feb 15 01:25 enter_download_mode.py
-rwx------ 1 root root 152156 Feb 15 01:25 dfu-util-x86_64-linux
root@localhost:/data/smart_dsu/board/tools$ cd ..
root@localhost:/data/smart_dsu/board$ make recover
arm-none-eabi-gcc -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/startup_stm32f413xx.o -c startup_stm32f413xx.s
echo "const uint8_t gitversion[] = \"v1.5.9-EON-897ae87b-"DEBUG"\";" > obj/gitversion.h
../crypto/getcertheader.py ../certs/debug.pub ../certs/release.pub > obj/cert.h
arm-none-eabi-gcc -MT obj/bootstub.panda.o -MMD -MP -MF generated_dependencies/bootstub.Td -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/bootstub.panda.o -c bootstub.c
arm-none-eabi-gcc -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/sha.panda.o -c ../crypto/sha.c
arm-none-eabi-gcc -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/rsa.panda.o -c ../crypto/rsa.c
arm-none-eabi-gcc -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/bootstub.panda.elf obj/startup_stm32f413xx.o obj/bootstub.panda.o obj/sha.panda.o obj/rsa.panda.o
arm-none-eabi-objcopy -v -O binary obj/bootstub.panda.elf obj/bootstub.panda.bin
copy from `obj/bootstub.panda.elf' [elf32-littlearm] to `obj/bootstub.panda.bin' [binary]
arm-none-eabi-gcc -MT obj/main.panda.o -MMD -MP -MF generated_dependencies/main.Td -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/main.panda.o -c main.c
arm-none-eabi-gcc -Wl,--section-start,.isr_vector=0x8004000 -g -Wall -Wextra -Wstrict-prototypes -Werror -mlittle-endian -mthumb -mcpu=cortex-m4 -mhard-float -DSTM32F4 -DSTM32F413xx -mfpu=fpv4-sp-d16 -fsingle-precision-constant -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os -Tstm32_flash.ld "-DEON" "-DALLOW_DEBUG" -o obj/panda.elf obj/startup_stm32f413xx.o obj/main.panda.o
arm-none-eabi-objcopy -v -O binary obj/panda.elf obj/code.bin
copy from `obj/panda.elf' [elf32-littlearm] to `obj/code.bin' [binary]
SETLEN=1 ../crypto/sign.py obj/code.bin obj/panda.bin ../certs/debug
signing 28812 bytes
hash: adfc1f196364b7d553b3d50fa7cb99b3b6fb1f38
PYTHONPATH=../ python3 -c "from python import Panda; Panda().reset(enter_bootloader=True)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/data/smart_dsu/python/__init__.py", line 152, in __init__
    self.connect(claim)
  File "/data/smart_dsu/python/__init__.py", line 197, in connect
    assert(self._handle != None)
AssertionError
make: [build.mk:45: recover] Error 1 (ignored)
sleep 1.0
"tools/dfu-util-aarch64" -d 0483:df11 -a 0 -s 0x08004000 -D obj/panda.bin
dfu-util 0.8

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2014 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to dfu-util@lists.gnumonks.org

tools/dfu-util-aarch64: Invalid DFU suffix signature
tools/dfu-util-aarch64: A valid DFU suffix will be required in a future dfu-util release!!!
Opening DFU capable USB device...
ID 0483:df11
Run-time device DFU version 011a
Claiming USB DFU Interface...
Setting Alternate Setting #0 ...
Determining device status: state = dfuERROR, status = 10
dfuERROR, clearing status
Determining device status: state = dfuIDLE, status = 0
dfuIDLE, continuing
DFU mode device DFU version 011a
Device returned transfer size 2048
DfuSe interface name: "Internal Flash  "
Downloading to address = 0x08004000, size = 28940
Download        [=========================] 100%        28940 bytes
Download done.
File downloaded successfully
"tools/dfu-util-aarch64" -d 0483:df11 -a 0 -s 0x08000000:leave -D obj/bootstub.panda.bin
dfu-util 0.8

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2014 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to dfu-util@lists.gnumonks.org

tools/dfu-util-aarch64: Invalid DFU suffix signature
tools/dfu-util-aarch64: A valid DFU suffix will be required in a future dfu-util release!!!
Opening DFU capable USB device...
ID 0483:df11
Run-time device DFU version 011a
Claiming USB DFU Interface...
Setting Alternate Setting #0 ...
Determining device status: state = dfuIDLE, status = 0
dfuIDLE, continuing
DFU mode device DFU version 011a
Device returned transfer size 2048
DfuSe interface name: "Internal Flash  "
Downloading to address = 0x08000000, size = 11676
Download        [=========================] 100%        11676 bytes
Download done.
File downloaded successfully
Transitioning to dfuMANIFEST state